### PR TITLE
Fix encountered install issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@ This repository contains the Radar Relay Bot example used in the [Building a Bot
 
 ## Setup
 
-1. `npm install`
 
-2. `export RADAR_WALLET_PASSWORD=yourpassword`
+1. Ensure you are running Node.js `8.x` as this is the only version currently supported.
 
-3. Run: `npm start` 
+2. `npm install`
+
+3. `export RADAR_WALLET_PASSWORD=yourpassword`
+
+4. Run: `npm start` 
 
   The first time you run the bot it will output the wallet address and wait to receive Kovan ETH.
   Enter the address into a [Kovan Faucet](https://faucet.kovan.network/) to obtain Kovan ETH.
 
-4. Once the ETH is received the bot will:
+5. Once the ETH is received the bot will:
    1. Set WETH token allowance
    2. Wrap ETH
    3. Subscribe to the ZRX/WETH book websocket

--- a/package-lock.json
+++ b/package-lock.json
@@ -1429,8 +1429,7 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "2.5.7"
       }
     },
     "babel-template": {
@@ -6231,9 +6230,9 @@
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -10,16 +10,23 @@
   },
   "author": "Mike Roth <mike@radarrelay.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=8 <10"
+  },
   "dependencies": {
     "@radarrelay/sdk": "^2.2.2",
     "@radarrelay/types": "^1.2.1",
     "bignumber.js": "^4.1.0",
     "colors": "^1.3.0",
     "request": "^2.85.0",
+    "regenerator-runtime": "^0.13.3",
     "request-promise": "^4.2.2",
     "typescript": "^2.8.3"
   },
   "devDependencies": {
     "@types/request-promise": "~4.1.42"
+  },
+  "resolutions": {
+    "bitcore-lib": "0.16.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'regenerator-runtime/runtime';
 import {SdkManager, EventName} from '@radarrelay/sdk';
 import {WebsocketRequestTopic, UserOrderType} from '@radarrelay/types';
 import colors = require('colors/safe');
@@ -23,7 +24,7 @@ const KOVAN_RPC = 'https://kovan.infura.io/radar';
   }
 
   // Handle errors
-  process.on('unhandledRejection', (reason, p) => {
+  process.on('unhandledRejection', (reason: Error | any, p) => {
     const message = reason.message ? reason.message.split('\n')[0] : reason;
     console.log(colors.red(message));
     process.exit(0);


### PR DESCRIPTION
Addresses following issues:

- Only Node.js 8.x is supported by `@radarrelay/sdk`.
- The `@ledgerhq/hw-transport-u2f` library exports pre `es2017` code and depends on `regenerator-runtime` but doesn't itself package it.
- The `bitcore-lib` library doesn't support multiple different versions being used at the same time, yet we transitively depend on two versions.
- TypeScript seems to infer the type of `process.on('unhandledRejection')` as being `{}`, which is incorrect, so explicitly type.
